### PR TITLE
Make it work on stable Rust

### DIFF
--- a/benches/peek.rs
+++ b/benches/peek.rs
@@ -1,4 +1,8 @@
-use crate::PeekRead;
+#![feature(test)]
+
+extern crate test;
+
+use peekbufread::PeekRead;
 use rand::prelude::*;
 use std::io::Cursor;
 use test::Bencher;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,20 +20,6 @@
 //! read.read(&mut buf).ok();
 //! ```
 
-#![cfg(test)]
-#![feature(test)]
-
-#[cfg(test)]
-extern crate test;
-
-#[cfg(test)]
-mod tests;
-#[cfg(test)]
-mod tests_exact;
-
-#[cfg(test)]
-mod bench;
-
 /// Peekable for IO-read. Works by buffering peeked data.
 /// Also supports checkpoints.
 pub struct PeekRead<Read: std::io::Read> {

--- a/tests/peek.rs
+++ b/tests/peek.rs
@@ -1,206 +1,177 @@
-use crate::PeekRead;
+use peekbufread::PeekRead;
 use std::io::Read;
 
 #[test]
-fn peek_exact() {
+fn peek() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    // Buffered in read, so check peek_exact again
+    // Buffered in read, so check peek again
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_read_512() {
-    const LEN: usize = 13 * 128;
-    let test = "hello, world!".repeat(LEN / 13).into_bytes();
-    let test: &[u8] = test.as_ref();
-    let mut read = PeekRead::new(test);
-
-    let mut buf: [u8; 128] = [0; 128];
-    let result = read.peek_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[..128], &buf);
-
-    let mut buf: [u8; 200] = [0; 200];
-    let result = read.peek_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[..200], &buf);
-
-    let mut buf: [u8; 140] = [0; 140];
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[..140], &buf);
-
-    let mut buf: [u8; LEN - 140] = [0; LEN - 140];
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[140..], &buf);
-}
-
-#[test]
-fn peek_read_512_exact_128() {
-    const LEN: usize = 13 * 128;
-    let test = "hello, world!".repeat(LEN / 13).into_bytes();
-    let test: &[u8] = test.as_ref();
-    let mut read = PeekRead::new(test);
-
-    let mut buf: [u8; 128] = [0; 128];
-    let result = read.peek_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[..128], &buf);
-
-    let mut buf: [u8; 128] = [0; 128];
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[..128], &buf);
-
-    let mut buf: [u8; LEN - 128] = [0; LEN - 128];
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(&test[128..], &buf);
-}
-
-#[test]
-fn peek_exact_partial() {
+fn peek_partial() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
-    // Buffered in read, so check peek_exact again
-    let result = read.peek_exact(&mut buf);
+    // Buffered in read, so check peek again
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 }
 
 #[test]
-fn peek_exact_partial_then_all() {
+fn peek_partial_then_all() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
-    // Buffered in read, so check peek_exact again
+    // Buffered in read, so check peek again
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_exact_all_read_partial() {
+fn peek_all_read_partial() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
 #[test]
-fn read_partial_then_peek_exact() {
+fn read_partial_then_peek() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
-    let result = read.read_exact(&mut [0; 2]);
+    let result = read.read(&mut [0; 2]);
     assert!(result.is_ok());
+    assert_eq!(2, result.unwrap());
 
     let mut buf: [u8; 9] = [0; 9];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(9, result.unwrap());
     assert_eq!(&test[2..11], buf);
 }
 
 #[test]
-fn peek_read_exact() {
+fn peek_read() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_err());
+    let result = read.read(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(0, result.unwrap());
 }
 
 #[test]
-fn partial_peek_peek_read_exact() {
+fn partial_peek_peek_read() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_err());
+    let result = read.read(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(0, result.unwrap());
 }
 
 #[test]
-fn partial_peek_read_read_exact() {
+fn partial_peek_read_read() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_err());
+    let result = read.read(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(0, result.unwrap());
 }
 
 #[test]
@@ -209,17 +180,20 @@ fn peek_partial_read_all() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read_exact(&mut buf);
-    assert!(result.is_err());
+    let result = read.read(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(0, result.unwrap());
 }
 
 #[test]
@@ -228,20 +202,24 @@ fn peek_partial_read_peek() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
@@ -251,23 +229,27 @@ fn peek_read_peek() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(&test[..12], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
@@ -279,8 +261,9 @@ fn checkpoint_read_ok() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 5] = [0; 5];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(5, result.unwrap());
         assert_eq!(&test[..5], &buf);
 
         return Ok(());
@@ -288,8 +271,9 @@ fn checkpoint_read_ok() {
     .ok();
 
     let mut buf: [u8; 7] = [0; 7];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(7, result.unwrap());
     assert_eq!(&test[5..], &buf);
 }
 
@@ -301,8 +285,9 @@ fn checkpoint_read_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 12] = [0; 12];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(12, result.unwrap());
         assert_eq!(&test[..12], &buf);
 
         return Err(());
@@ -310,8 +295,9 @@ fn checkpoint_read_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -323,8 +309,9 @@ fn checkpoint_read_partial_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -332,21 +319,23 @@ fn checkpoint_read_partial_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn checkpoint_peek_exact_err() {
+fn checkpoint_peek_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 12] = [0; 12];
-        let result = read.peek_exact(&mut buf);
+        let result = read.peek(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(12, result.unwrap());
         assert_eq!(&test[..12], &buf);
 
         return Err(());
@@ -354,21 +343,23 @@ fn checkpoint_peek_exact_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn checkpoint_peek_exact_partial_err() {
+fn checkpoint_peek_partial_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.peek_exact(&mut buf);
+        let result = read.peek(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -376,8 +367,9 @@ fn checkpoint_peek_exact_partial_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -388,14 +380,16 @@ fn read_partial_checkpoint_read_err() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -403,26 +397,29 @@ fn read_partial_checkpoint_read_err() {
     .ok();
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn read_partial_checkpoint_read_peek_exact_err() {
+fn read_partial_checkpoint_read_peek_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.peek_exact(&mut buf);
+        let result = read.peek(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -430,8 +427,9 @@ fn read_partial_checkpoint_read_peek_exact_err() {
     .ok();
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 }
 
@@ -444,8 +442,9 @@ fn checkpoint_ok_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(6, result.unwrap());
             assert_eq!(&test[..6], &buf);
 
             return Ok(());
@@ -453,8 +452,9 @@ fn checkpoint_ok_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -462,27 +462,30 @@ fn checkpoint_ok_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn partial_peek_exact_checkpoint_ok_in_checkpoint_err() {
+fn partial_peek_checkpoint_ok_in_checkpoint_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 4] = [0; 4];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(4, result.unwrap());
     assert_eq!(&test[..4], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(6, result.unwrap());
             assert_eq!(&test[4..10], &buf);
 
             return Ok(());
@@ -490,8 +493,9 @@ fn partial_peek_exact_checkpoint_ok_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 2] = [0; 2];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(2, result.unwrap());
         assert_eq!(&test[10..], &buf);
 
         return Err(());
@@ -499,8 +503,9 @@ fn partial_peek_exact_checkpoint_ok_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(8, result.unwrap());
     assert_eq!(&test[4..], &buf);
 }
 
@@ -512,14 +517,16 @@ fn checkpoint_ok_after_in_checkpoint_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(6, result.unwrap());
             assert_eq!(&test[6..], &buf);
 
             return Ok(());
@@ -531,26 +538,29 @@ fn checkpoint_ok_after_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn partial_peek_exact_checkpoint_err_in_checkpoint_err() {
+fn partial_peek_checkpoint_err_in_checkpoint_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
     let mut buf: [u8; 4] = [0; 4];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(4, result.unwrap());
     assert_eq!(&test[..4], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(4, result.unwrap());
             assert_eq!(&test[4..8], &buf);
 
             return Err(());
@@ -558,8 +568,9 @@ fn partial_peek_exact_checkpoint_err_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[4..10], &buf);
 
         return Err(());
@@ -567,8 +578,9 @@ fn partial_peek_exact_checkpoint_err_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(8, result.unwrap());
     assert_eq!(&test[4..], &buf);
 }
 
@@ -581,8 +593,9 @@ fn checkpoint_err_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(4, result.unwrap());
             assert_eq!(&test[..4], &buf);
 
             return Err(());
@@ -590,8 +603,9 @@ fn checkpoint_err_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -599,8 +613,9 @@ fn checkpoint_err_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -613,8 +628,9 @@ fn checkpoint_err_equal_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(6, result.unwrap());
             assert_eq!(&test[..6], &buf);
 
             return Err(());
@@ -622,8 +638,9 @@ fn checkpoint_err_equal_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -631,8 +648,9 @@ fn checkpoint_err_equal_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -644,14 +662,16 @@ fn checkpoint_err_after_in_checkpoint_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read_exact(&mut buf);
+        let result = read.read(&mut buf);
         assert!(result.is_ok());
+        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read_exact(&mut buf);
+            let result = read.read(&mut buf);
             assert!(result.is_ok());
+            assert_eq!(4, result.unwrap());
             assert_eq!(&test[6..10], &buf);
 
             return Err(());
@@ -663,19 +683,21 @@ fn checkpoint_err_after_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read_exact(&mut buf);
+    let result = read.read(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_exact_read_until() {
+fn peek_read_until() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     use std::io::BufRead;
@@ -683,18 +705,20 @@ fn peek_exact_read_until() {
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 }
 
 #[test]
-fn partial_peek_exact_read_until() {
+fn partial_peek_read_until() {
     let test = b"hello, world";
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(8, result.unwrap());
     assert_eq!(&test[..8], &buf);
 
     use std::io::BufRead;
@@ -702,29 +726,34 @@ fn partial_peek_exact_read_until() {
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek_exact(&mut buf);
+    let result = read.peek(&mut buf);
     assert!(result.is_ok());
+    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
+    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 }

--- a/tests/peek_exact.rs
+++ b/tests/peek_exact.rs
@@ -1,177 +1,206 @@
-use crate::PeekRead;
+use peekbufread::PeekRead;
 use std::io::Read;
 
 #[test]
-fn peek() {
+fn peek_exact() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    // Buffered in read, so check peek again
+    // Buffered in read, so check peek_exact again
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_partial() {
+fn peek_read_512() {
+    const LEN: usize = 13 * 128;
+    let test = "hello, world!".repeat(LEN / 13).into_bytes();
+    let test: &[u8] = test.as_ref();
+    let mut read = PeekRead::new(test);
+
+    let mut buf: [u8; 128] = [0; 128];
+    let result = read.peek_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[..128], &buf);
+
+    let mut buf: [u8; 200] = [0; 200];
+    let result = read.peek_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[..200], &buf);
+
+    let mut buf: [u8; 140] = [0; 140];
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[..140], &buf);
+
+    let mut buf: [u8; LEN - 140] = [0; LEN - 140];
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[140..], &buf);
+}
+
+#[test]
+fn peek_read_512_exact_128() {
+    const LEN: usize = 13 * 128;
+    let test = "hello, world!".repeat(LEN / 13).into_bytes();
+    let test: &[u8] = test.as_ref();
+    let mut read = PeekRead::new(test);
+
+    let mut buf: [u8; 128] = [0; 128];
+    let result = read.peek_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[..128], &buf);
+
+    let mut buf: [u8; 128] = [0; 128];
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[..128], &buf);
+
+    let mut buf: [u8; LEN - 128] = [0; LEN - 128];
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_ok());
+    assert_eq!(&test[128..], &buf);
+}
+
+#[test]
+fn peek_exact_partial() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
-    // Buffered in read, so check peek again
-    let result = read.peek(&mut buf);
+    // Buffered in read, so check peek_exact again
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 }
 
 #[test]
-fn peek_partial_then_all() {
+fn peek_exact_partial_then_all() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
-    // Buffered in read, so check peek again
+    // Buffered in read, so check peek_exact again
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_all_read_partial() {
+fn peek_exact_all_read_partial() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
 #[test]
-fn read_partial_then_peek() {
+fn read_partial_then_peek_exact() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
-    let result = read.read(&mut [0; 2]);
+    let result = read.read_exact(&mut [0; 2]);
     assert!(result.is_ok());
-    assert_eq!(2, result.unwrap());
 
     let mut buf: [u8; 9] = [0; 9];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(9, result.unwrap());
     assert_eq!(&test[2..11], buf);
 }
 
 #[test]
-fn peek_read() {
+fn peek_read_exact() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(0, result.unwrap());
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_err());
 }
 
 #[test]
-fn partial_peek_peek_read() {
+fn partial_peek_peek_read_exact() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(0, result.unwrap());
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_err());
 }
 
 #[test]
-fn partial_peek_read_read() {
+fn partial_peek_read_read_exact() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 
-    let result = read.read(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(0, result.unwrap());
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -180,20 +209,17 @@ fn peek_partial_read_all() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
-    let result = read.read(&mut buf);
-    assert!(result.is_ok());
-    assert_eq!(0, result.unwrap());
+    let result = read.read_exact(&mut buf);
+    assert!(result.is_err());
 }
 
 #[test]
@@ -202,24 +228,20 @@ fn peek_partial_read_peek() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
@@ -229,27 +251,23 @@ fn peek_read_peek() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(&test[..12], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..12], &buf);
 }
 
@@ -261,9 +279,8 @@ fn checkpoint_read_ok() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 5] = [0; 5];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(5, result.unwrap());
         assert_eq!(&test[..5], &buf);
 
         return Ok(());
@@ -271,9 +288,8 @@ fn checkpoint_read_ok() {
     .ok();
 
     let mut buf: [u8; 7] = [0; 7];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(7, result.unwrap());
     assert_eq!(&test[5..], &buf);
 }
 
@@ -285,9 +301,8 @@ fn checkpoint_read_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 12] = [0; 12];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(12, result.unwrap());
         assert_eq!(&test[..12], &buf);
 
         return Err(());
@@ -295,9 +310,8 @@ fn checkpoint_read_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -309,9 +323,8 @@ fn checkpoint_read_partial_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -319,23 +332,21 @@ fn checkpoint_read_partial_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn checkpoint_peek_err() {
+fn checkpoint_peek_exact_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 12] = [0; 12];
-        let result = read.peek(&mut buf);
+        let result = read.peek_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(12, result.unwrap());
         assert_eq!(&test[..12], &buf);
 
         return Err(());
@@ -343,23 +354,21 @@ fn checkpoint_peek_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn checkpoint_peek_partial_err() {
+fn checkpoint_peek_exact_partial_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.peek(&mut buf);
+        let result = read.peek_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -367,9 +376,8 @@ fn checkpoint_peek_partial_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -380,16 +388,14 @@ fn read_partial_checkpoint_read_err() {
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -397,29 +403,26 @@ fn read_partial_checkpoint_read_err() {
     .ok();
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn read_partial_checkpoint_read_peek_err() {
+fn read_partial_checkpoint_read_peek_exact_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.peek(&mut buf);
+        let result = read.peek_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -427,9 +430,8 @@ fn read_partial_checkpoint_read_peek_err() {
     .ok();
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[6..], &buf);
 }
 
@@ -442,9 +444,8 @@ fn checkpoint_ok_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(6, result.unwrap());
             assert_eq!(&test[..6], &buf);
 
             return Ok(());
@@ -452,9 +453,8 @@ fn checkpoint_ok_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[6..], &buf);
 
         return Err(());
@@ -462,30 +462,27 @@ fn checkpoint_ok_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn partial_peek_checkpoint_ok_in_checkpoint_err() {
+fn partial_peek_exact_checkpoint_ok_in_checkpoint_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 4] = [0; 4];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(4, result.unwrap());
     assert_eq!(&test[..4], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(6, result.unwrap());
             assert_eq!(&test[4..10], &buf);
 
             return Ok(());
@@ -493,9 +490,8 @@ fn partial_peek_checkpoint_ok_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 2] = [0; 2];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(2, result.unwrap());
         assert_eq!(&test[10..], &buf);
 
         return Err(());
@@ -503,9 +499,8 @@ fn partial_peek_checkpoint_ok_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(8, result.unwrap());
     assert_eq!(&test[4..], &buf);
 }
 
@@ -517,16 +512,14 @@ fn checkpoint_ok_after_in_checkpoint_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(6, result.unwrap());
             assert_eq!(&test[6..], &buf);
 
             return Ok(());
@@ -538,29 +531,26 @@ fn checkpoint_ok_after_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[cfg(feature = "checkpoint")]
 #[test]
-fn partial_peek_checkpoint_err_in_checkpoint_err() {
+fn partial_peek_exact_checkpoint_err_in_checkpoint_err() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
     let mut buf: [u8; 4] = [0; 4];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(4, result.unwrap());
     assert_eq!(&test[..4], &buf);
 
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(4, result.unwrap());
             assert_eq!(&test[4..8], &buf);
 
             return Err(());
@@ -568,9 +558,8 @@ fn partial_peek_checkpoint_err_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[4..10], &buf);
 
         return Err(());
@@ -578,9 +567,8 @@ fn partial_peek_checkpoint_err_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(8, result.unwrap());
     assert_eq!(&test[4..], &buf);
 }
 
@@ -593,9 +581,8 @@ fn checkpoint_err_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(4, result.unwrap());
             assert_eq!(&test[..4], &buf);
 
             return Err(());
@@ -603,9 +590,8 @@ fn checkpoint_err_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -613,9 +599,8 @@ fn checkpoint_err_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -628,9 +613,8 @@ fn checkpoint_err_equal_in_checkpoint_err() {
     read.checkpoint(|read| -> Result<(), ()> {
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 6] = [0; 6];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(6, result.unwrap());
             assert_eq!(&test[..6], &buf);
 
             return Err(());
@@ -638,9 +622,8 @@ fn checkpoint_err_equal_in_checkpoint_err() {
         .ok();
 
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         return Err(());
@@ -648,9 +631,8 @@ fn checkpoint_err_equal_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
@@ -662,16 +644,14 @@ fn checkpoint_err_after_in_checkpoint_err() {
 
     read.checkpoint(|read| -> Result<(), ()> {
         let mut buf: [u8; 6] = [0; 6];
-        let result = read.read(&mut buf);
+        let result = read.read_exact(&mut buf);
         assert!(result.is_ok());
-        assert_eq!(6, result.unwrap());
         assert_eq!(&test[..6], &buf);
 
         read.checkpoint(|read| -> Result<(), ()> {
             let mut buf: [u8; 4] = [0; 4];
-            let result = read.read(&mut buf);
+            let result = read.read_exact(&mut buf);
             assert!(result.is_ok());
-            assert_eq!(4, result.unwrap());
             assert_eq!(&test[6..10], &buf);
 
             return Err(());
@@ -683,21 +663,19 @@ fn checkpoint_err_after_in_checkpoint_err() {
     .ok();
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.read(&mut buf);
+    let result = read.read_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 }
 
 #[test]
-fn peek_read_until() {
+fn peek_exact_read_until() {
     let test = b"hello, world";
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 12] = [0; 12];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(12, result.unwrap());
     assert_eq!(test, &buf);
 
     use std::io::BufRead;
@@ -705,20 +683,18 @@ fn peek_read_until() {
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 }
 
 #[test]
-fn partial_peek_read_until() {
+fn partial_peek_exact_read_until() {
     let test = b"hello, world";
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 8] = [0; 8];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(8, result.unwrap());
     assert_eq!(&test[..8], &buf);
 
     use std::io::BufRead;
@@ -726,34 +702,29 @@ fn partial_peek_read_until() {
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 6] = [0; 6];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 
     let mut read = PeekRead::new(test.as_ref());
 
     let mut buf: [u8; 5] = [0; 5];
-    let result = read.peek(&mut buf);
+    let result = read.peek_exact(&mut buf);
     assert!(result.is_ok());
-    assert_eq!(5, result.unwrap());
     assert_eq!(&test[..5], &buf);
 
     let mut buf = Vec::new();
     let result = read.read_until(b',', &mut buf);
     assert!(result.is_ok());
-    assert_eq!(6, result.unwrap());
     assert_eq!(&test[..6], &buf);
 }


### PR DESCRIPTION
Due to `cfg(test)` being set, this library is not able to be used outside of tests. Importing it would fail with:

    error[E0432]: unresolved import `peekbufread::PeekRead`

With the `features(test)` being set it's not possible to use it on stable Rust. Importing it would fail with:

    error[E0554]: `#![feature]` may not be used on the stable release channel

With separating things into the usual directory structure of the library source, tests and benchmarks, it's now possible to use this library also on stable Rust.

For the benchmarks nightly is still required.